### PR TITLE
Move metadata outside init

### DIFF
--- a/athena/__init__.py
+++ b/athena/__init__.py
@@ -6,16 +6,6 @@ __all__ = [
     'utils'
 ]
 
-__project__ = 'ATHENA'
-__title__ = "athena"
-__author__ = "Marco Tezzele, Francesco Romor"
-__copyright__ = "Copyright 2019-2020, Athena contributors"
-__license__ = "MIT"
-__version__ = "0.0.2"
-__mail__ = 'marcotez@gmail.com, francesco.romor@gmail.com'
-__maintainer__ = __author__
-__status__ = "Beta"
-
 from .active import ActiveSubspaces
 from .feature_map import (FeatureMap, rff_map, rff_jac)
 from .kas import KernelActiveSubspaces

--- a/athena/meta.py
+++ b/athena/meta.py
@@ -1,0 +1,23 @@
+"""
+Package metadata
+"""
+__all__ = [
+    '__project__',
+    '__title__',
+    '__author__',
+    '__copyright__',
+    '__license__',
+    '__version__',
+    '__mail__',
+    '__maintainer__',
+    '__status__']
+
+__project__ = 'ATHENA'
+__title__ = "athena"
+__author__ = "Marco Tezzele, Francesco Romor"
+__copyright__ = "Copyright 2019-2020, Athena contributors"
+__license__ = "MIT"
+__version__ = "0.0.2"
+__mail__ = 'marcotez@gmail.com, francesco.romor@gmail.com'
+__maintainer__ = __author__
+__status__ = "Beta"

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,17 @@
 from setuptools import setup
-import athena
+
+meta = {}
+with open("athena/meta.py") as fp:
+    exec(fp.read(), meta)
 
 # Package meta-data.
-NAME = athena.__title__
+NAME = meta['__title__']
 DESCRIPTION = 'Advanced Techniques for High dimensional parameter spaces to ' \
               'Enhance Numerical Analysis'
 URL = 'https://github.com/mathLab/ATHENA'
-MAIL = athena.__mail__
-AUTHOR = athena.__author__
-VERSION = athena.__version__
+MAIL = meta['__mail__']
+AUTHOR = meta['__author__']
+VERSION = meta['__version__']
 KEYWORDS = 'parameter-space-reduction active-subspaces ' \
            'kernel-active-subspaces model-reduction sensitivity-analysis ' \
            'nonlinear-level-set-learning'


### PR DESCRIPTION
- allow for automatic dependencies installation using setup.py/pip (before there was a little bug, see https://github.com/mathLab/EZyRB/issues/124)